### PR TITLE
fix: CQDG-670 config return, only required fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ Keyckloak Authentication server information :
 - `AUTH_REALM` : Keycloak Realm
 - `AUTH_CLIENT_ID` : Id of the client that contains resource definition and permissions
 - `AUTH_CLIENT_SECRET` : Secret of the client that contains resource definition and permissions
-- `AUTH_DEVICE_CLIENT_ID` : Id of the client with OAuth 2 device authorization granted. Required if `FERLOAD_CLIENT_METHOD` is `device`.
-- `AUTH_DEVICE_CLIENT_SECRET` : Secret of the client with OAuth 2 device authorization granted. Required if `FERLOAD_CLIENT_METHOD` is `device`.
+- `AUTH_AUDIENCE_CLIENT_ID` : Id of the public client, with OAuth 2 device authorization granted. Required if `FERLOAD_CLIENT_METHOD` is `device`.
 - `AUTH_RESOURCES_POLICY_GLOBAL_NAME` : Name of the resource a user should have access to be able to download all files.
   Works only with endpoints that fetch files by urls. Can be empty.
 

--- a/src/main/scala/bio/ferlab/ferload/Config.scala
+++ b/src/main/scala/bio/ferlab/ferload/Config.scala
@@ -81,8 +81,7 @@ case class AuthConfig(
                        realm: String,
                        clientId: String,
                        clientSecret: String,
-                       deviceClientId: Option[String],
-                       deviceClientSecret: Option[String],
+                       audience: Option[String],
                        resourcesGlobalName: Option[String]
                      ) {
   val baseUri = s"$authUrl/realms/$realm"
@@ -95,15 +94,11 @@ object AuthConfig {
       sys.env("AUTH_REALM"),
       sys.env("AUTH_CLIENT_ID"),
       sys.env("AUTH_CLIENT_SECRET"),
-      sys.env.get("AUTH_DEVICE_CLIENT_ID"),
-      sys.env.get("AUTH_DEVICE_CLIENT_SECRET"),
+      sys.env.get("AUTH_AUDIENCE_CLIENT_ID"),
       sys.env.get("AUTH_RESOURCES_POLICY_GLOBAL_NAME")
     )
-    if (sys.env.getOrElse("FERLOAD_CLIENT_METHOD", "token") == DEVICE && f.deviceClientId.isEmpty) {
-      throw new IllegalArgumentException(s"When FERLOAD_CLIENT_METHOD is `device`, AUTH_DEVICE_CLIENT_ID must be provided")
-    }
-    if (sys.env.getOrElse("FERLOAD_CLIENT_METHOD", "token") == DEVICE && f.deviceClientSecret.isEmpty) {
-      throw new IllegalArgumentException(s"When FERLOAD_CLIENT_METHOD is `device`, AUTH_DEVICE_CLIENT_SECRET must be provided")
+    if (sys.env.getOrElse("FERLOAD_CLIENT_METHOD", "token") == DEVICE && f.audience.isEmpty) {
+      throw new IllegalArgumentException(s"When FERLOAD_CLIENT_METHOD is `device`, AUTH_AUDIENCE_CLIENT_ID must be provided")
     }
     f
   }

--- a/src/main/scala/bio/ferlab/ferload/endpoints/ConfigEndpoint.scala
+++ b/src/main/scala/bio/ferlab/ferload/endpoints/ConfigEndpoint.scala
@@ -25,9 +25,8 @@ object ConfigEndpoint:
       val kc = KeycloakConfig(config.auth.authUrl, config.auth.realm, config.ferloadClientConfig.clientId, config.auth.clientId)
       IO.pure(FerloadConfig(config.ferloadClientConfig.method, Some(kc), None))
     } else if (config.ferloadClientConfig.method == FerloadClientConfig.DEVICE) {
-      val kc = KeycloakConfig(config.auth.authUrl, config.auth.realm, config.ferloadClientConfig.clientId, config.auth.clientId, config.auth.deviceClientId)
-      val deviceConfig = TokenConfig(config.auth.realm, config.ferloadClientConfig.clientId, config.ferloadClientConfig.tokenLink.get, config.ferloadClientConfig.tokenHelper)
-      IO.pure(FerloadConfig(config.ferloadClientConfig.method, Some(kc), Some(deviceConfig)))
+      val kc = KeycloakConfig(config.auth.authUrl, config.auth.realm, config.auth.clientId, config.auth.audience.get)
+      IO.pure(FerloadConfig(config.ferloadClientConfig.method, Some(kc), None))
     }
     else {
       IO.raiseError(new IllegalStateException(s"Invalid configuration type ${config.ferloadClientConfig.method}"))

--- a/src/main/scala/bio/ferlab/ferload/model/FerloadConfig.scala
+++ b/src/main/scala/bio/ferlab/ferload/model/FerloadConfig.scala
@@ -6,6 +6,6 @@ import scala.annotation.targetName
 
 case class FerloadConfig(method: String, keycloak: Option[KeycloakConfig], tokenConfig: Option[TokenConfig])
 
-case class KeycloakConfig(url: String, realm: String, `client-id`: String, audience: String, `device-client`: Option[String] = None)
+case class KeycloakConfig(url: String, realm: String, `client-id`: String, audience: String)
 
 case class TokenConfig(realm:String, `client-id`: String, link: String, helper: Option[String])

--- a/src/test/scala/bio/ferlab/ferload/endpoints/ConfigEndpointsSpec.scala
+++ b/src/test/scala/bio/ferlab/ferload/endpoints/ConfigEndpointsSpec.scala
@@ -19,7 +19,7 @@ class ConfigEndpointsSpec extends AnyFlatSpec with Matchers with EitherValues:
   "config" should "return expected config for password method" in {
     //given
     val config = Config(
-      AuthConfig("http://localhost:8080", "realm", "clientId", "clientSecret", None, None, None),
+      AuthConfig("http://localhost:8080", "realm", "clientId", "clientSecret", None, None),
       HttpConfig("localhost", 9090),
       S3Config(Some("accessKey"), Some("secretKey"), Some("endpoint"), Some("bucket"), false, Some("region"), 3600),
       DrsConfig("ferlaod", "Ferload", "ferload.ferlab.bio", "1.3.0", "Ferlab", "https://ferlab.bio"),
@@ -41,7 +41,7 @@ class ConfigEndpointsSpec extends AnyFlatSpec with Matchers with EitherValues:
   it should "return expected config for token method" in {
     //given
     val config = Config(
-      AuthConfig("http://localhost:8080", "realm", "clientId", "clientSecret", None, None, None),
+      AuthConfig("http://localhost:8080", "realm", "clientId", "clientSecret", None, None),
       HttpConfig("localhost", 9090),
       S3Config(Some("accessKey"), Some("secretKey"), Some("endpoint"), Some("bucket"), false, Some("region"), 3600),
       DrsConfig("ferlaod", "Ferload", "ferload.ferlab.bio", "1.3.0", "Ferlab", "https://ferlab.bio"),
@@ -63,7 +63,7 @@ class ConfigEndpointsSpec extends AnyFlatSpec with Matchers with EitherValues:
   it should "return expected config for device method" in {
     //given
     val config = Config(
-      AuthConfig("http://localhost:8080", "realm", "clientId", "clientSecret", Some("deviceClient"), Some("deviceClientSecret"), None),
+      AuthConfig("http://localhost:8080", "realm", "resource_client", "clientSecret", Some("cqdg_acl"), None),
       HttpConfig("localhost", 9090),
       S3Config(Some("accessKey"), Some("secretKey"), Some("endpoint"), Some("bucket"), false, Some("region"), 3600),
       DrsConfig("ferlaod", "Ferload", "ferload.ferlab.bio", "1.3.0", "Ferlab", "https://ferlab.bio"),
@@ -80,8 +80,8 @@ class ConfigEndpointsSpec extends AnyFlatSpec with Matchers with EitherValues:
 
     val expected = FerloadConfig(
       FerloadClientConfig.DEVICE,
-      Some(KeycloakConfig("http://localhost:8080", "realm", "ferloadClientId", "clientId", Some("deviceClient"))),
-      Some(TokenConfig("realm", "ferloadClientId", "https://ferload.ferlab.bio/token", Some("Please copy / paste this url in your browser to get a new authentication token.")))
+      Some(KeycloakConfig("http://localhost:8080", "realm", "resource_client", "cqdg_acl")),
+      None
     )
     response.map(_.body.value shouldBe expected).unwrap
   }

--- a/src/test/scala/bio/ferlab/ferload/services/AuthorizationServiceSpec.scala
+++ b/src/test/scala/bio/ferlab/ferload/services/AuthorizationServiceSpec.scala
@@ -19,7 +19,7 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
       .whenRequestMatches(_ => true)
       .thenRespond(""" {"access_token": "E123456", "expires_in": 65, "refresh_expires_in": 0, "token_type" : "bearer"} """)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
     authorizationService.requestPartyToken("https://ferlab.bio", Seq("FI1")).unwrap shouldBe "E123456"
     testingBackend.allInteractions.size shouldBe 1
@@ -34,7 +34,7 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
       .whenRequestMatches(_ => true)
       .thenRespond(""" {"error": "invalid_token"}""", statusCode = StatusCode.Forbidden)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
     a[HttpError[_]] should be thrownBy {
       authorizationService.requestPartyToken("https://ferlab.bio", Seq("FI1")).unwrap
@@ -66,7 +66,7 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           |} """.stripMargin)
     )
 
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
     val resp = authorizationService.introspectPartyToken("E123456").unwrap
@@ -97,7 +97,7 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           |} """.stripMargin)
     )
 
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
@@ -128,7 +128,7 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           |} """.stripMargin)
     )
 
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
@@ -161,7 +161,7 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | ]
           |} """.stripMargin)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
@@ -195,7 +195,7 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | ]
           |} """.stripMargin)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
@@ -229,7 +229,7 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | ]
           |} """.stripMargin)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 

--- a/src/test/scala/bio/ferlab/ferload/services/ResourceServiceSpec.scala
+++ b/src/test/scala/bio/ferlab/ferload/services/ResourceServiceSpec.scala
@@ -18,7 +18,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with EitherValues {
       .whenRequestMatches(_ => true)
       .thenRespond(""" {"access_token": "E123456", "expires_in": 65, "refresh_expires_in": 0, "token_type" : "bearer"} """)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val resourceService = new ResourceService(authConfig, testingBackend)
     resourceService.clientToken().unwrap shouldBe PartyToken("E123456", 65, 0, None, "bearer")
@@ -29,7 +29,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with EitherValues {
       .whenRequestMatches(_ => true)
       .thenRespond(""" {"error": "invalid_token"}""", statusCode = StatusCode.Forbidden)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val resourceService = new ResourceService(authConfig, testingBackend)
     val error = the[HttpError[_]] thrownBy {
@@ -48,7 +48,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with EitherValues {
       .whenRequestMatches(r => r.uri.path == Seq("realms", "realm", "authz", "protection", "resource_set", "F1") && r.method.method == "GET")
       .thenRespond("", statusCode = StatusCode.Ok)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val resourceService = new ResourceService(authConfig, testingBackend)
     resourceService.existResource("F1").unwrap shouldBe StatusCode.Ok
@@ -61,7 +61,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with EitherValues {
       .whenRequestMatches(r => r.uri.path == Seq("realms", "realm", "authz", "protection", "resource_set", "F1"))
       .thenRespond("", statusCode = StatusCode.NotFound)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val resourceService = new ResourceService(authConfig, testingBackend)
     resourceService.existResource("F1").unwrap shouldBe StatusCode.NotFound
@@ -118,7 +118,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with EitherValues {
           |}
           | """.stripMargin, statusCode = StatusCode.Ok)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val resourceService = new ResourceService(authConfig, testingBackend)
     resourceService.getResourceById("FI1").unwrap shouldBe ReadResource(


### PR DESCRIPTION
Only required keycloak client (audience)  should be provided to the ferlaod CLI (in exemple is the `audience: cqdg_acl` client):

![Screenshot from 2024-04-04 16-50-40](https://github.com/Ferlab-Ste-Justine/ferload/assets/29788342/b78e2a12-e47e-47fa-9bc0-3537f13197f7)

for method `device`, only this field is really required to be passed to the Ferload CLI.

Assumptions on audience client:
1. client must be public
2. must have -> `OAuth 2.0 Device Authorization Grant` checked 

![Screenshot from 2024-04-04 16-55-40](https://github.com/Ferlab-Ste-Justine/ferload/assets/29788342/96bec7b0-7db2-4d4e-9f6f-aaae124f33cd)


