### PR TITLE
fix: CQDG-793 update for cavatica

### DIFF
--- a/src/main/scala/bio/ferlab/ferload/Config.scala
+++ b/src/main/scala/bio/ferlab/ferload/Config.scala
@@ -35,6 +35,7 @@ case class DrsConfig(
                       selfHost: String,
                       organizationName: String,
                       organizationUrl: String,
+                      accessId: String,
                       description: Option[String] = None,
                       contactUrl: Option[String] = None,
                       documentationUrl: Option[String] = None,
@@ -50,11 +51,11 @@ object DrsConfig {
       sys.env("DRS_SELF_HOST"),
       sys.env("DRS_ORGANIZATION_NAME"),
       sys.env("DRS_ORGANIZATION_URL"),
+      sys.env("DRS_ACCESS_ID"),
       sys.env.get("DRS_DESCRIPTION"),
       sys.env.get("DRS_CONTACT_URL"),
       sys.env.get("DRS_DOCUMENTATION_URL"),
       sys.env.get("DRS_ENVIRONMENT"),
-
     )
   }
 }

--- a/src/main/scala/bio/ferlab/ferload/endpoints/DrsEndpoints.scala
+++ b/src/main/scala/bio/ferlab/ferload/endpoints/DrsEndpoints.scala
@@ -17,9 +17,9 @@ import sttp.tapir.server.ServerEndpoint
 
 object DrsEndpoints:
   val baseEndpoint: Endpoint[Unit, Unit, Unit, Unit, Any] = endpoint
-    .prependSecurityIn("ga4gh")
-    .prependSecurityIn("drs")
     .prependSecurityIn("v1")
+    .prependSecurityIn("drs")
+    .prependSecurityIn("ga4gh")
 
   private val service = baseEndpoint.get
     .in("service-info")
@@ -59,6 +59,17 @@ object DrsEndpoints:
       .get
       .out(jsonBody[DrsObject])
 
+
+  private def getAccessMethod(authorizationService: AuthorizationService) =
+    objectEnpoint
+      .securityIn(auth.bearer[String]())
+      .securityIn(path[String].name("object_id"))
+      .securityIn("access" / path[String].name("access_id"))
+      .errorOut(statusCode.and(jsonBody[ErrorResponse]))
+      .serverSecurityLogic((token, objectId, accessId) => authorizationService.authLogic(token, Seq(objectId), Some(accessId)))
+      .get
+      .out(jsonBody[AccessURL])
+
   private val createObject: Endpoint[Unit, (String, CreateDrsObject), (StatusCode, ErrorResponse), StatusCode, Any] =
     baseEndpoint
       .in("object")
@@ -78,14 +89,25 @@ object DrsEndpoints:
     }
   }
 
-  private def getObjectServer(config: Config, authorizationService: AuthorizationService, resourceService: ResourceService, s3Service: S3Service) = getObject(authorizationService).serverLogicSuccess { user =>
+  private def getObjectServer(config: Config, authorizationService: AuthorizationService, resourceService: ResourceService) = getObject(authorizationService).serverLogicSuccess { (user, _) =>
     _ =>
       for {
-        resource <- resourceService.getResourceById(user.permissions.head.resource_id)
+        resource <- resourceService.getResourceById(user.permissions.head.rsid)
+      // For now, we only have a unique accessId (all resources are in CEPH S3)
+      } yield DrsObject.build(resource, config.drsConfig.accessId, config.drsConfig.selfHost)
+  }
+
+
+  private def getAccessMethodServer(authorizationService: AuthorizationService, resourceService: ResourceService, s3Service: S3Service) = getAccessMethod(authorizationService).serverLogicSuccess { (user, accessId) =>
+    _ =>
+      //fetch according to accessId, it is unique for now
+      for {
+        resource <- resourceService.getResourceById(user.permissions.head.rsid)
         bucketAndPath <- IO.fromTry(S3Service.parseS3Urls(resource.uris))
         (bucket, path) = bucketAndPath
         url = s3Service.presignedUrl(bucket, path)
-      } yield DrsObject.build(resource, url, config.drsConfig.selfHost)
+      } yield
+        AccessURL.build(url)
   }
 
   private def createObjectServer(config: Config, resourceService: ResourceService) = createObject.serverLogicSuccess { (token, createDrsObject) =>
@@ -102,6 +124,7 @@ object DrsEndpoints:
   def all(config: Config, authorizationService: AuthorizationService, resourceService: ResourceService, s3Service: S3Service): Seq[ServerEndpoint[Any, IO]] = Seq(
     serviceServer(config.drsConfig),
     objectInfoServer(config, resourceService),
-    getObjectServer(config, authorizationService, resourceService, s3Service),
+    getObjectServer(config, authorizationService, resourceService),
+    getAccessMethodServer(authorizationService, resourceService, s3Service),
     createObjectServer(config, resourceService)
   )

--- a/src/main/scala/bio/ferlab/ferload/endpoints/LegacyObjectEndpoints.scala
+++ b/src/main/scala/bio/ferlab/ferload/endpoints/LegacyObjectEndpoints.scala
@@ -15,13 +15,13 @@ import sttp.tapir.server.*
 object LegacyObjectEndpoints:
 
 
-  private def securedGlobalEndpoint(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, User, Unit, (StatusCode, ErrorResponse), Unit, Any, IO] =
+  private def securedGlobalEndpoint(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, (User, Option[String]), Unit, (StatusCode, ErrorResponse), Unit, Any, IO] =
     endpoint
       .securityIn(auth.bearer[String]())
       .errorOut(statusCode.and(jsonBody[ErrorResponse]))
       .serverSecurityLogic(token => authorizationService.authLogic(token, Seq(resourceGlobalName)))
 
-  private def objectByPath(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, User, List[String], (StatusCode, ErrorResponse), ObjectUrl, Any, IO] =
+  private def objectByPath(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, (User, Option[String]), List[String], (StatusCode, ErrorResponse), ObjectUrl, Any, IO] =
     securedGlobalEndpoint(authorizationService, resourceGlobalName)
       .get
       .description("Retrieve an object by its path and return an url to download it")
@@ -29,7 +29,7 @@ object LegacyObjectEndpoints:
       .in(paths.description("Path of the object to retrieve"))
       .out(jsonBody[ObjectUrl])
 
-  private def objectsByPaths(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, User, String, (StatusCode, ErrorResponse), Map[String, String], Any, IO] =
+  private def objectsByPaths(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, (User, Option[String]), String, (StatusCode, ErrorResponse), Map[String, String], Any, IO] =
     securedGlobalEndpoint(authorizationService, resourceGlobalName)
       .description("Retrieve a list of objects by their paths and return a list of download URLs for each object")
       .deprecated()

--- a/src/main/scala/bio/ferlab/ferload/endpoints/LegacyObjectEndpoints.scala
+++ b/src/main/scala/bio/ferlab/ferload/endpoints/LegacyObjectEndpoints.scala
@@ -15,22 +15,22 @@ import sttp.tapir.server.*
 object LegacyObjectEndpoints:
 
 
-  private def securedGlobalEndpoint(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, (User, Option[String]), Unit, (StatusCode, ErrorResponse), Unit, Any, IO] =
+  private def securedGlobalEndpoint(authorizationService: AuthorizationService, resourceGlobalName: String, method: String): PartialServerEndpoint[String, (User, Option[String]), Unit, (StatusCode, ErrorResponse), Unit, Any, IO] =
     endpoint
       .securityIn(auth.bearer[String]())
       .errorOut(statusCode.and(jsonBody[ErrorResponse]))
-      .serverSecurityLogic(token => authorizationService.authLogic(token, Seq(resourceGlobalName)))
+      .serverSecurityLogic(token => authorizationService.authLogic(token, Seq(resourceGlobalName), method: String))
 
-  private def objectByPath(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, (User, Option[String]), List[String], (StatusCode, ErrorResponse), ObjectUrl, Any, IO] =
-    securedGlobalEndpoint(authorizationService, resourceGlobalName)
+  private def objectByPath(authorizationService: AuthorizationService, resourceGlobalName: String, method: String): PartialServerEndpoint[String, (User, Option[String]), List[String], (StatusCode, ErrorResponse), ObjectUrl, Any, IO] =
+    securedGlobalEndpoint(authorizationService, resourceGlobalName, method)
       .get
       .description("Retrieve an object by its path and return an url to download it")
       .deprecated()
       .in(paths.description("Path of the object to retrieve"))
       .out(jsonBody[ObjectUrl])
 
-  private def objectsByPaths(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, (User, Option[String]), String, (StatusCode, ErrorResponse), Map[String, String], Any, IO] =
-    securedGlobalEndpoint(authorizationService, resourceGlobalName)
+  private def objectsByPaths(authorizationService: AuthorizationService, resourceGlobalName: String, method: String): PartialServerEndpoint[String, (User, Option[String]), String, (StatusCode, ErrorResponse), Map[String, String], Any, IO] =
+    securedGlobalEndpoint(authorizationService, resourceGlobalName, method)
       .description("Retrieve a list of objects by their paths and return a list of download URLs for each object")
       .deprecated()
       .post
@@ -41,13 +41,13 @@ object LegacyObjectEndpoints:
         .example(Map("file1.vcf" -> "https://file1.vcf", "file2.vcf" -> "https://file2.vcf"))
       )
 
-  def objectByPathServer(authorizationService: AuthorizationService, s3Service: S3Service, resourceGlobalName: String, defaultBucket: String): ServerEndpoint[Any, IO] =
-    objectByPath(authorizationService, resourceGlobalName).serverLogicSuccess { user =>
+  def objectByPathServer(authorizationService: AuthorizationService, s3Service: S3Service, resourceGlobalName: String, defaultBucket: String, method: String): ServerEndpoint[Any, IO] =
+    objectByPath(authorizationService, resourceGlobalName, method).serverLogicSuccess { user =>
       file => s3Service.presignedUrl(defaultBucket, file.mkString("/")).pure[IO].map(ObjectUrl.apply)
     }
 
-  def listObjectsByPathServer(authorizationService: AuthorizationService, s3Service: S3Service, resourceGlobalName: String, defaultBucket: String): ServerEndpoint[Any, IO] =
-    objectsByPaths(authorizationService, resourceGlobalName).serverLogicSuccess { user =>
+  def listObjectsByPathServer(authorizationService: AuthorizationService, s3Service: S3Service, resourceGlobalName: String, defaultBucket: String, method: String): ServerEndpoint[Any, IO] =
+    objectsByPaths(authorizationService, resourceGlobalName, method).serverLogicSuccess { user =>
       files =>
         files.split("\n")
           .toList
@@ -59,8 +59,8 @@ object LegacyObjectEndpoints:
       b <- config.s3Config.defaultBucket
       r <- config.auth.resourcesGlobalName
       servers = List(
-        listObjectsByPathServer(authorizationService, s3Service, r, b),
-        objectByPathServer(authorizationService, s3Service, r, b)
+        listObjectsByPathServer(authorizationService, s3Service, r, b, config.ferloadClientConfig.method),
+        objectByPathServer(authorizationService, s3Service, r, b, config.ferloadClientConfig.method)
       )
     } yield servers
     s.getOrElse(Nil)

--- a/src/main/scala/bio/ferlab/ferload/endpoints/ObjectsEndpoints.scala
+++ b/src/main/scala/bio/ferlab/ferload/endpoints/ObjectsEndpoints.scala
@@ -20,26 +20,26 @@ object ObjectsEndpoints:
 
     private val byIdEndpoint = baseEndpoint.securityIn("objects")
 
-    private def singleObject(authorizationService: AuthorizationService): PartialServerEndpoint[(String, String), (User, Option[String]), Unit, (StatusCode, ErrorResponse), ObjectUrl, Any, IO] = byIdEndpoint
+    private def singleObject(authorizationService: AuthorizationService, method: String): PartialServerEndpoint[(String, String), (User, Option[String]), Unit, (StatusCode, ErrorResponse), ObjectUrl, Any, IO] = byIdEndpoint
       .get
       .securityIn(path[String].name("object_id"))
-      .serverSecurityLogic((token, objectId) => authorizationService.authLogic(token, Seq(objectId)))
+      .serverSecurityLogic((token, objectId) => authorizationService.authLogic(token, Seq(objectId), method))
       .description("Retrieve an object by its id and return an url to download it")
       .out(jsonBody[ObjectUrl])
 
-    private def listObjects(authorizationService: AuthorizationService): PartialServerEndpoint[(String, String), (User, Option[String]), Unit, (StatusCode, ErrorResponse), Map[String, String], Any, IO] = byIdEndpoint
+    private def listObjects(authorizationService: AuthorizationService, method: String): PartialServerEndpoint[(String, String), (User, Option[String]), Unit, (StatusCode, ErrorResponse), Map[String, String], Any, IO] = byIdEndpoint
       .post
       .securityIn("list")
       .securityIn(stringBody.description("List of ids of objects to retrieve").example("FI1\nFI2"))
-      .serverSecurityLogic((token, objects) => authorizationService.authLogic(token, objects.split("\n")))
+      .serverSecurityLogic((token, objects) => authorizationService.authLogic(token, objects.split("\n"), method))
       .description("Retrieve an object by its id and return an url to download it")
       .out(jsonBody[Map[String, String]]
         .description("List of files URLs by object id")
         .example(Map("FI1" -> "https://file1.vcf", "FI2" -> "https://file2.vcf")))
 
 
-    def singleObjectServer(authorizationService: AuthorizationService, resourceService: ResourceService, s3Service: S3Service): ServerEndpoint[Any, IO] =
-      singleObject(authorizationService).serverLogicSuccess { (user, _) =>
+    def singleObjectServer(authorizationService: AuthorizationService, resourceService: ResourceService, s3Service: S3Service, method: String): ServerEndpoint[Any, IO] =
+      singleObject(authorizationService, method).serverLogicSuccess { (user, _) =>
         _ =>
           for {
             resource <- resourceService.getResourceById(user.permissions.head.rsid)
@@ -51,8 +51,8 @@ object ObjectsEndpoints:
       }
 
 
-    def listObjectsServer(authorizationService: AuthorizationService, resourceService: ResourceService, s3Service: S3Service): ServerEndpoint[Any, IO] =
-      listObjects(authorizationService).serverLogicSuccess { (user, _) =>
+    def listObjectsServer(authorizationService: AuthorizationService, resourceService: ResourceService, s3Service: S3Service, method: String): ServerEndpoint[Any, IO] =
+      listObjects(authorizationService, method).serverLogicSuccess { (user, _) =>
         _ =>
           val resourcesIO: IO[List[ReadResource]] = user.permissions.toList.traverse(p => resourceService.getResourceById(p.rsid))
           resourcesIO.map { resources =>
@@ -64,31 +64,31 @@ object ObjectsEndpoints:
 
       }
 
-    def all(authorizationService: AuthorizationService, resourceService: ResourceService, s3Service: S3Service): Seq[ServerEndpoint[Any, IO]] = List(
-      singleObjectServer(authorizationService, resourceService, s3Service),
-      listObjectsServer(authorizationService, resourceService, s3Service)
+    def all(authorizationService: AuthorizationService, resourceService: ResourceService, s3Service: S3Service, method: String): Seq[ServerEndpoint[Any, IO]] = List(
+      singleObjectServer(authorizationService, resourceService, s3Service, method),
+      listObjectsServer(authorizationService, resourceService, s3Service, method)
     )
 
   object ByPath:
-    private def byPathEndpoint(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, (User, Option[String]), Unit, (StatusCode, ErrorResponse), Unit, Any, IO] =
+    private def byPathEndpoint(authorizationService: AuthorizationService, resourceGlobalName: String, method: String): PartialServerEndpoint[String, (User, Option[String]), Unit, (StatusCode, ErrorResponse), Unit, Any, IO] =
       baseEndpoint
         .securityIn("objects")
         .securityIn("bypath")
-        .serverSecurityLogic(token => authorizationService.authLogic(token, Seq(resourceGlobalName)))
+        .serverSecurityLogic(token => authorizationService.authLogic(token, Seq(resourceGlobalName), method))
 
-    private def singleObject(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, (User, Option[String]), String, (StatusCode, ErrorResponse), ObjectUrl, Any, IO] =
-      byPathEndpoint(authorizationService, resourceGlobalName)
+    private def singleObject(authorizationService: AuthorizationService, resourceGlobalName: String, method: String): PartialServerEndpoint[String, (User, Option[String]), String, (StatusCode, ErrorResponse), ObjectUrl, Any, IO] =
+      byPathEndpoint(authorizationService, resourceGlobalName, method)
         .get
         .description("Retrieve an object by its path and return an url to download it")
         .in(query[String]("path").description("Path of the object to retrieve").example("dir1/file1.vcf"))
         .out(jsonBody[ObjectUrl])
 
-    def singleObjectServer(authorizationService: AuthorizationService, s3Service: S3Service, resourceGlobalName: String, defaultBucket: String): ServerEndpoint[Any, IO] =
-      singleObject(authorizationService, resourceGlobalName).serverLogicSuccess { user =>
+    def singleObjectServer(authorizationService: AuthorizationService, s3Service: S3Service, resourceGlobalName: String, defaultBucket: String, method: String): ServerEndpoint[Any, IO] =
+      singleObject(authorizationService, resourceGlobalName, method).serverLogicSuccess { user =>
         file => s3Service.presignedUrl(defaultBucket, file).pure[IO].map(ObjectUrl.apply)
       }
 
-    private def listObjects(authorizationService: AuthorizationService, resourceGlobalName: String): PartialServerEndpoint[String, (User, Option[String]), String, (StatusCode, ErrorResponse), Map[String, String], Any, IO] = byPathEndpoint(authorizationService, resourceGlobalName)
+    private def listObjects(authorizationService: AuthorizationService, resourceGlobalName: String, method: String): PartialServerEndpoint[String, (User, Option[String]), String, (StatusCode, ErrorResponse), Map[String, String], Any, IO] = byPathEndpoint(authorizationService, resourceGlobalName, method)
       .description("Retrieve a list of objects by their path and return a list of download URLs for each object")
       .post
       .in("list")
@@ -98,7 +98,7 @@ object ObjectsEndpoints:
         .example(Map("dir1/file1.vcf" -> "https://file1.vcf", "dir1/file2.vcf" -> "https://file2.vcf"))
       )
 
-    def listObjectsServer(authorizationService: AuthorizationService, s3Service: S3Service, resourceGlobalName: String, defaultBucket: String): ServerEndpoint[Any, IO] = listObjects(authorizationService, resourceGlobalName).serverLogicSuccess { user =>
+    def listObjectsServer(authorizationService: AuthorizationService, s3Service: S3Service, resourceGlobalName: String, defaultBucket: String, method: String): ServerEndpoint[Any, IO] = listObjects(authorizationService, resourceGlobalName, method).serverLogicSuccess { user =>
       files =>
         files.split("\n")
           .toList
@@ -110,8 +110,8 @@ object ObjectsEndpoints:
         b <- config.s3Config.defaultBucket
         r <- config.auth.resourcesGlobalName
         servers = List(
-          singleObjectServer(authorizationService, s3Service, r, b),
-          listObjectsServer(authorizationService, s3Service, r, b)
+          singleObjectServer(authorizationService, s3Service, r, b, config.ferloadClientConfig.method),
+          listObjectsServer(authorizationService, s3Service, r, b, config.ferloadClientConfig.method)
         )
       } yield servers
       s.getOrElse(Nil)
@@ -119,5 +119,5 @@ object ObjectsEndpoints:
     }
 
   def all(config: Config, authorizationService: AuthorizationService, resourceService: ResourceService, s3Service: S3Service): Seq[ServerEndpoint[Any, IO]] =
-    ByPath.all(config, authorizationService, s3Service) ++ ById.all(authorizationService, resourceService, s3Service)
+    ByPath.all(config, authorizationService, s3Service) ++ ById.all(authorizationService, resourceService, s3Service, config.ferloadClientConfig.method)
 

--- a/src/main/scala/bio/ferlab/ferload/endpoints/PermissionsEndpoints.scala
+++ b/src/main/scala/bio/ferlab/ferload/endpoints/PermissionsEndpoints.scala
@@ -54,7 +54,7 @@ object PermissionsEndpoints:
     private def listPermissionsServer(authorizationService: AuthorizationService): ServerEndpoint[Any, IO] =
       listPermissions(authorizationService).serverLogicSuccess { user =>
         _ =>
-          IO(user.permissions.map(_.resource_id).toList)
+          IO(user.permissions.map(_.rsid).toList)
       }
 
     def all(authorizationService: AuthorizationService): Seq[ServerEndpoint[Any, IO]] = List(

--- a/src/main/scala/bio/ferlab/ferload/model/IntrospectResponse.scala
+++ b/src/main/scala/bio/ferlab/ferload/model/IntrospectResponse.scala
@@ -1,3 +1,16 @@
 package bio.ferlab.ferload.model
 
-case class IntrospectResponse(active: Boolean, exp: Option[Int], iat: Option[Int], aud: Option[String], nbf: Option[Int], permissions: Option[Seq[Permissions]])
+case class IntrospectResponse(
+                               active: Boolean,
+                               exp: Option[Int],
+                               iat: Option[Int],
+                               aud: Option[String],
+                               sub: Option[String],
+                               azp: Option[String],
+                               nbf: Option[Int],
+                               authorization: Option[Authorisation]
+                             )
+
+case class Authorisation(
+                          permissions: Seq[Permissions]
+                        )

--- a/src/main/scala/bio/ferlab/ferload/model/Permissions.scala
+++ b/src/main/scala/bio/ferlab/ferload/model/Permissions.scala
@@ -1,3 +1,3 @@
 package bio.ferlab.ferload.model
 
-case class Permissions(resource_id: String, rsname: Option[String], resource_scopes: Seq[String])
+case class Permissions(rsid: String, rsname: Option[String], scopes: Seq[String])

--- a/src/main/scala/bio/ferlab/ferload/model/drs/AccessURL.scala
+++ b/src/main/scala/bio/ferlab/ferload/model/drs/AccessURL.scala
@@ -5,7 +5,17 @@ package bio.ferlab.ferload.model.drs
  * @param headers An optional list of headers to include in the HTTP request to `url`. These headers can be used to provide auth tokens required to fetch the object bytes. for example: ''Authorization: Basic Z2E0Z2g6ZHJz''
  */
 case class AccessURL (
-  url: String,
+  url: Option[String],
   headers: Option[List[String]]
 )
+
+object AccessURL {
+  def build(url: String): AccessURL = {
+    AccessURL(
+      Some(url),
+      None
+    )
+  }
+
+}
 

--- a/src/main/scala/bio/ferlab/ferload/model/drs/DrsObject.scala
+++ b/src/main/scala/bio/ferlab/ferload/model/drs/DrsObject.scala
@@ -36,15 +36,15 @@ case class DrsObject(
                     )
 
 object DrsObject {
-  def build(resource: ReadResource, presignedUrl: String, host: String): DrsObject = {
+  def build(resource: ReadResource, access_id: String, host: String): DrsObject = {
 
     val accessMethods = AccessMethod(
       `type` = "https",
       access_url = Some(AccessURL(
-        url = presignedUrl,
+        url = None,
         headers = None
       )),
-      access_id = None,
+      access_id = Some(access_id),
       region = None,
       authorizations = None
 

--- a/src/test/scala/bio/ferlab/ferload/endpoints/ConfigEndpointsSpec.scala
+++ b/src/test/scala/bio/ferlab/ferload/endpoints/ConfigEndpointsSpec.scala
@@ -22,7 +22,7 @@ class ConfigEndpointsSpec extends AnyFlatSpec with Matchers with EitherValues:
       AuthConfig("http://localhost:8080", "realm", "clientId", "clientSecret", None, None),
       HttpConfig("localhost", 9090),
       S3Config(Some("accessKey"), Some("secretKey"), Some("endpoint"), Some("bucket"), false, Some("region"), 3600),
-      DrsConfig("ferlaod", "Ferload", "ferload.ferlab.bio", "1.3.0", "Ferlab", "https://ferlab.bio"),
+      DrsConfig("ferlaod", "Ferload", "ferload.ferlab.bio", "1.3.0", "Ferlab", "https://ferlab.bio", accessId = "accessId"),
       FerloadClientConfig(FerloadClientConfig.PASSWORD, "ferloadClientId", None, None)
     )
     val backendStub = TapirStubInterpreter(SttpBackendStub(new CatsMonadError[IO]()))
@@ -44,7 +44,7 @@ class ConfigEndpointsSpec extends AnyFlatSpec with Matchers with EitherValues:
       AuthConfig("http://localhost:8080", "realm", "clientId", "clientSecret", None, None),
       HttpConfig("localhost", 9090),
       S3Config(Some("accessKey"), Some("secretKey"), Some("endpoint"), Some("bucket"), false, Some("region"), 3600),
-      DrsConfig("ferlaod", "Ferload", "ferload.ferlab.bio", "1.3.0", "Ferlab", "https://ferlab.bio"),
+      DrsConfig("ferlaod", "Ferload", "ferload.ferlab.bio", "1.3.0", "Ferlab", "https://ferlab.bio", accessId = "accessId"),
       FerloadClientConfig(FerloadClientConfig.TOKEN, "ferloadClientId", Some("https://ferload.ferlab.bio/token"), Some("Please copy / paste this url in your browser to get a new authentication token."))
     )
     val backendStub = TapirStubInterpreter(SttpBackendStub(new CatsMonadError[IO]()))
@@ -77,7 +77,7 @@ class ConfigEndpointsSpec extends AnyFlatSpec with Matchers with EitherValues:
       AuthConfig("http://localhost:8080", "realm", "resource_client", "clientSecret", Some("cqdg_acl"), None),
       HttpConfig("localhost", 9090),
       S3Config(Some("accessKey"), Some("secretKey"), Some("endpoint"), Some("bucket"), false, Some("region"), 3600),
-      DrsConfig("ferlaod", "Ferload", "ferload.ferlab.bio", "1.3.0", "Ferlab", "https://ferlab.bio"),
+      DrsConfig("ferlaod", "Ferload", "ferload.ferlab.bio", "1.3.0", "Ferlab", "https://ferlab.bio", accessId = "accessId"),
       FerloadClientConfig(FerloadClientConfig.DEVICE, "ferloadClientId", Some("https://ferload.ferlab.bio/token"), Some("Please copy / paste this url in your browser to get a new authentication token."))
     )
     val backendStub = TapirStubInterpreter(SttpBackendStub(new CatsMonadError[IO]()))

--- a/src/test/scala/bio/ferlab/ferload/services/AuthorizationServiceSpec.scala
+++ b/src/test/scala/bio/ferlab/ferload/services/AuthorizationServiceSpec.scala
@@ -2,7 +2,7 @@ package bio.ferlab.ferload.services
 
 import bio.ferlab.ferload.AuthConfig
 import bio.ferlab.ferload.unwrap
-import bio.ferlab.ferload.model.{ErrorResponse, IntrospectResponse, Permissions, User}
+import bio.ferlab.ferload.model.{Authorisation, ErrorResponse, IntrospectResponse, Permissions, User}
 import cats.effect.IO
 import io.circe.Json
 import io.circe.parser.parse
@@ -58,21 +58,23 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | "iat": 20,
           | "aud" : "cqdg",
           | "nbf": 4,
+          | "authorization":{
           | "permissions" : [
           |   {
-          |     "resource_id": "F1",
+          |     "rsid": "F1",
           |     "rsname": "F1 Name",
-          |     "resource_scopes": ["Scope1", "Scope2"]
+          |     "scopes": ["Scope1", "Scope2"]
           |   }
           | ]
+          | }
           |} """.stripMargin)
     )
 
     val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
-    val resp = authorizationService.introspectPartyToken("E123456").unwrap
-    resp shouldBe IntrospectResponse(active = true, exp = Some(65), iat = Some(20), aud = Some("cqdg"), nbf = Some(4), permissions = Some(Seq(Permissions("F1", Some("F1 Name"), Seq("Scope1", "Scope2")))))
+    val resp = authorizationService.introspectToken("E123456").unwrap
+    resp shouldBe IntrospectResponse(active = true, exp = Some(65), iat = Some(20), aud = Some("cqdg"), sub = None, azp = None, nbf = Some(4), authorization = Some(Authorisation(Seq(Permissions("F1", Some("F1 Name"), Seq("Scope1", "Scope2"))))))
 
 
   }
@@ -89,21 +91,24 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | "iat": 20,
           | "aud" : "cqdg",
           | "nbf": 4,
+          | "azp": "allowed_client",
+          | "authorization":{
           | "permissions" : [
           |   {
-          |     "resource_id": "F1",
+          |     "rsid": "F1",
           |     "rsname": "F1",
-          |     "resource_scopes": ["Scope1", "Scope2"]
+          |     "scopes": ["Scope1", "Scope2"]
           |   }
           | ]
+          | }
           |} """.stripMargin)
     )
 
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("allowed_client"), None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
-    authorizationService.authLogic("token", Seq("F1")).unwrap.value shouldBe User("token", Set(Permissions("F1", Some("F1"), Seq("Scope1", "Scope2"))))
+    authorizationService.authLogic("token", Seq("F1")).unwrap.value._1 shouldBe User("token", Set(Permissions("F1", Some("F1"), Seq("Scope1", "Scope2"))))
   }
 
   it should "return a forbidden if user dont have access to all resources" in {
@@ -119,18 +124,21 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | "exp": 65,
           | "iat": 20,
           | "aud" : "cqdg",
+          | "azp": "allowed_client",
           | "nbf": 4,
+          | "authorization":{
           | "permissions" : [
           |   {
-          |     "resource_id": "F1",
+          |     "rsid": "F1",
           |     "rsname": "F1",
-          |     "resource_scopes": ["Scope1", "Scope2"]
+          |     "scopes": ["Scope1", "Scope2"]
           |   }
           | ]
+          | }
           |} """.stripMargin)
     )
 
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("allowed_client"), None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
@@ -154,16 +162,19 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | "iat": 20,
           | "aud" : "cqdg",
           | "nbf": 4,
+          | "azp": "allowed_client",
+          | "authorization":{
           | "permissions" : [
           |   {
-          |     "resource_id": "F1",
+          |     "rsid": "F1",
           |     "rsname": "F1",
-          |     "resource_scopes": ["Scope1", "Scope2"]
+          |     "scopes": ["Scope1", "Scope2"]
           |   }
           | ]
+          | }
           |} """.stripMargin)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("allowed_client"), None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
@@ -188,16 +199,19 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | "iat": 20,
           | "aud" : "cqdg",
           | "nbf": 4,
+          | "azp": "allowed_client",
+          | "authorization":{
           | "permissions" : [
           |   {
-          |     "resource_id": "F1",
+          |     "rsid": "F1",
           |     "rsname": "F1",
-          |     "resource_scopes": ["Scope1", "Scope2"]
+          |     "scopes": ["Scope1", "Scope2"]
           |   }
           | ]
+          | }
           |} """.stripMargin)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("allowed_client"), None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
@@ -222,20 +236,64 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | "iat": 20,
           | "aud" : "cqdg",
           | "nbf": 4,
+          | "azp": "allowed_client",
+          | "authorization":{
           | "permissions" : [
           |   {
-          |     "resource_id": "F1",
+          |     "rsid": "F1",
           |     "rsname": "F1",
-          |     "resource_scopes": ["Scope1", "Scope2"]
+          |     "scopes": ["Scope1", "Scope2"]
           |   }
           | ]
+          | }
           |} """.stripMargin)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("allowed_client"), None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
     authorizationService.authLogic("token", Seq("F1")).unwrap.left.value shouldBe(StatusCode.Unauthorized, ErrorResponse("Unauthorized", 401))
+  }
+
+  // authLogic does return pre-sign url, only authorized client should be granted access
+  it should "return forbidden for any client other then the authorized client" in {
+    val testingBackend = new RecordingSttpBackend(Http4sBackend.stub[IO]
+      .whenRequestMatches(r => r.uri.path == Seq("realms", "realm", "protocol", "openid-connect", "token"))
+      .thenRespond(""" {"access_token": "E123456", "expires_in": 65, "refresh_expires_in": 0, "token_type" : "bearer"} """)
+      .whenRequestMatches(r => r.uri.path.contains("introspect"))
+      .thenRespond(
+        """ {
+          | "active": true,
+          | "exp": 65,
+          | "iat": 20,
+          | "aud" : "cqdg",
+          | "nbf": 4,
+          | "azp": "allowed_client",
+          | "authorization":{
+          | "permissions" : [
+          |   {
+          |     "rsid": "F1",
+          |     "rsname": "F1",
+          |     "scopes": ["Scope1", "Scope2"]
+          |   }
+          | ]
+          | }
+          |} """.stripMargin)
+    )
+    val authConfigOk = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("allowed_client"), None)
+
+    val authorizationServiceOk = new AuthorizationService(authConfigOk, testingBackend)
+
+    // match client: allowed_client
+    authorizationServiceOk.authLogic("token", Seq("F1")).unwrap.value._1 shouldBe User("token", Set(Permissions("F1", Some("F1"), Seq("Scope1", "Scope2"))))
+
+    val authConfigNotOk = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("other_allowed_client"), None)
+
+    val authorizationServiceNotOk = new AuthorizationService(authConfigNotOk, testingBackend)
+
+    // not matching clients: allowed_client vs. other_allowed_client
+    authorizationServiceNotOk.authLogic("token", Seq("F1")).unwrap.left.value shouldBe(StatusCode.Forbidden, ErrorResponse("Unauthorized", 403))
+
   }
 
   "authLogicAuthorizationForUser" should "return a User" in {
@@ -250,17 +308,20 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | "iat": 20,
           | "aud" : "cqdg",
           | "nbf": 4,
+          | "azp": "allowed_client",
+          | "authorization":{
           | "permissions" : [
           |   {
-          |     "resource_id": "F1",
+          |     "rsid": "F1",
           |     "rsname": "F1",
-          |     "resource_scopes": ["Scope1", "Scope2"]
+          |     "scopes": ["Scope1", "Scope2"]
           |   }
           | ]
+          | }
           |} """.stripMargin)
     )
 
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("allowed_client"), None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
@@ -283,17 +344,20 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | "iat": 20,
           | "aud" : "cqdg",
           | "nbf": 4,
+          | "azp": "allowed_client",
+          | "authorization":{
           | "permissions" : [
           |   {
-          |     "resource_id": "F1",
+          |     "rsid": "F1",
           |     "rsname": "F1",
-          |     "resource_scopes": ["Scope1", "Scope2"]
+          |     "scopes": ["Scope1", "Scope2"]
           |   }
           | ]
+          | }
           |} """.stripMargin)
     )
 
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("allowed_client"), None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
@@ -320,21 +384,71 @@ class AuthorizationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
           | "iat": 20,
           | "aud" : "cqdg",
           | "nbf": 4,
+          | "azp": "allowed_client",
+          | "authorization":{
           | "permissions" : [
           |   {
-          |     "resource_id": "F1",
+          |     "rsid": "F1",
           |     "rsname": "F1",
-          |     "resource_scopes": ["Scope1", "Scope2"]
+          |     "scopes": ["Scope1", "Scope2"]
           |   }
           | ]
+          | }
           |} """.stripMargin)
     )
-    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", None, None)
+    val authConfig = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("allowed_client"), None)
 
     val authorizationService = new AuthorizationService(authConfig, testingBackend)
 
     val inputJson = parse("""{"file_ids":["FI1"]}""".stripMargin).getOrElse(Json.Null)
 
     authorizationService.authLogicAuthorizationForUser("token", inputJson).unwrap.left.value shouldBe(StatusCode.Unauthorized, ErrorResponse("Unauthorized", 401))
+  }
+
+  // authLogicAuthorizationForUser does not return any pre-sign url, all valid clients should be able to access
+  it should "authorize for any valid client" in {
+    val testingBackend = new RecordingSttpBackend(Http4sBackend.stub[IO]
+      .whenRequestMatches(r => {
+        r.uri.path == Seq("realms", "realm", "protocol", "openid-connect", "token")
+      })
+      .thenRespond(""" {"access_token": "E123456", "expires_in": 65, "refresh_expires_in": 0, "token_type" : "bearer"} """)
+      .whenRequestMatches(r => r.uri.path.contains("introspect"))
+      .thenRespond(
+        """ {
+          | "active": true,
+          | "exp": 65,
+          | "iat": 20,
+          | "aud" : "cqdg",
+          | "nbf": 4,
+          | "azp": "allowed_client",
+          | "authorization":{
+          | "permissions" : [
+          |   {
+          |     "rsid": "F1",
+          |     "rsname": "F1",
+          |     "scopes": ["Scope1", "Scope2"]
+          |   }
+          | ]
+          | }
+          |} """.stripMargin)
+    )
+    val authConfigOne = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("allowed_client"), None)
+
+    val authorizationServiceOne = new AuthorizationService(authConfigOne, testingBackend)
+
+    val inputJsonOne = parse("""{"file_ids":["FI1"]}""".stripMargin).getOrElse(Json.Null)
+
+    authorizationServiceOne.authLogicAuthorizationForUser("token", inputJsonOne).unwrap.value shouldBe User("token", Set(Permissions("F1", Some("F1"), Seq("Scope1", "Scope2"))))
+
+    //------------------------------------
+
+    val authConfigTwo = AuthConfig("http://stub.local", "realm", "clientId", "clientSecret", Some("other_allowed_client"), None)
+
+    val authorizationServiceTwo = new AuthorizationService(authConfigTwo, testingBackend)
+
+    val inputJsonTwo = parse("""{"file_ids":["FI1"]}""".stripMargin).getOrElse(Json.Null)
+
+    authorizationServiceTwo.authLogicAuthorizationForUser("token", inputJsonTwo).unwrap.value shouldBe User("token", Set(Permissions("F1", Some("F1"), Seq("Scope1", "Scope2"))))
+
   }
 }


### PR DESCRIPTION
Ref: [CQDG-793](https://ferlab-crsj.atlassian.net/browse/CQDG-793)

Changes:

1. Currently, with a valid token from the portal UI, a user can get a presign URL using the ferload server Endpoints. Any endpoint that returns a presign url should only accepts clients linked to a MFA. Others endpoints that only check permissions, etc.. should  be ok with any client that is valid.

2. The ordering of the DRS endpoint was wrong (see DRS documentation). Should be this `/ga4gh/drs/v1`:
![Screenshot from 2024-07-03 11-13-24](https://github.com/Ferlab-Ste-Justine/ferload/assets/29788342/b7445215-841a-41b2-ad55-b004a60f7774)

3. Followup discussions with Michele:
    a. `/ga4gh/drs/v1/objects/{object_id}` this endpoint will not return the presigned url directly. It will return the `DRSObject`  with a `null` value for the `access_url.url` as so. But it will return an access_id. This is necessary if we have files located on multiple platforms. For now, however, we only have files in Ceph S3, the `access_id` for now will have a unique single value.
    
![image](https://github.com/Ferlab-Ste-Justine/ferload/assets/29788342/5f9a63a2-71f2-4215-8070-e271f4c1c23b)

b. The access Endpoint will return the presign URL to download the file. 
 
![Screenshot from 2024-07-03 11-51-20](https://github.com/Ferlab-Ste-Justine/ferload/assets/29788342/fd156730-ce1a-4784-a392-a494371e0ac1)




[CQDG-793]: https://ferlab-crsj.atlassian.net/browse/CQDG-793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ